### PR TITLE
Added bootstrap.ignore_system_bootstrap_checks=true

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
     elasticsearch:
       image: elasticsearch:5
-      command: elasticsearch
+      command: elasticsearch -E bootstrap.ignore_system_bootstrap_checks=true
       environment:
         # This helps ES out with memory usage
         - ES_JAVA_OPTS=-Xmx1g -Xms1g


### PR DESCRIPTION
Great work with this! I ran into a small issue with ES 5 and was able to resolve it via the proposed changes.

From https://www.elastic.co/blog/elasticsearch-5-0-0-alpha3-released:
`A number of system checks are performed during node startup. Any failing checks will produce a warning when in development mode (bound to localhost) or a hard exception when in production mode (bound to a network interface other than localhost). These failing checks should be fixed before going into production, for the good of your cluster. Sometimes, however, you need to bind to a public interface while still in development so we have added an escape hatch setting which allows you to downgrade these exceptions to warnings. Just set bootstrap.ignore_system_bootstrap_checks to true.`

More discussion here: https://github.com/docker-library/elasticsearch/issues/98
